### PR TITLE
[WIP] Parametrise all versions

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,8 +1,8 @@
 name := "$name$"
 
-version := "0.1.0"
+version := "$projectVersion$"
 
-scalaVersion := "2.11.7"
+scalaVersion := "$scalaVersion$"
 
 resolvers ++= Seq(
   "IESL Release" at "https://dev-iesl.cs.umass.edu/nexus/content/groups/public",
@@ -15,8 +15,8 @@ resolvers ++= Seq(
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
 
 libraryDependencies ++= Seq(
-  "ml.wolfe" %% "wolfe-core" % "0.5.0",
-  "ml.wolfe" %% "wolfe-examples" % "0.5.0"
+  "ml.wolfe" %% "wolfe-core" % "$wolfeVersion$",
+  "ml.wolfe" %% "wolfe-examples" % "$wolfeVersion$"
 )
 
 initialCommands := """

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,2 +1,6 @@
 name=My Something Project
 description=Say something about this template.
+projectVersion=0.0.1
+sbtVersion=0.13.8
+scalaVersion=2.11.7
+wolfeVersion=0.5.0


### PR DESCRIPTION
All versions are now parametrised. 
- [x]  Parametrise project version
- [x]  Parametrise sbt version
- [x]  Parametrise scala version
- [x]  Parametrise wolfe version
- [ ]  if the user specifies a snapshot version for their project, the default wolfe version would also be the latest SNAPSHOT version. Otherwise it would be the latest release version.

I think the last point is resolved too but i'm not sure. If the user enters `0.5.0-SNAPSHOT` then that's what will be used. The default is `0.5.0`. Is this correct @riedelcastro 
